### PR TITLE
fix: Reopen NIC in settled failure state on bindings changes

### DIFF
--- a/.changeset/beige-worms-bow.md
+++ b/.changeset/beige-worms-bow.md
@@ -1,0 +1,5 @@
+---
+'dnssd-advertise': patch
+---
+
+Reopen NIC if it settled into a failure state, if its network bindings changed (e.g. WiFi disconnects and then reconnects)

--- a/src/__tests__/advertise.test.ts
+++ b/src/__tests__/advertise.test.ts
@@ -1,5 +1,17 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
+const { bindingKeysMock } = vi.hoisted(() => ({
+  bindingKeysMock: vi.fn<(bindings: unknown[]) => Set<string>>(),
+}));
+
+vi.mock('../nics', async () => {
+  const actual = await vi.importActual<typeof import('../nics')>('../nics');
+  return {
+    ...actual,
+    interfaceBindingKeys: bindingKeysMock,
+  };
+});
+
 import {
   advertiseInternal,
   createInterfaceAdvertiser,
@@ -156,11 +168,13 @@ const createMockServices = (
 describe('advertise', () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    bindingKeysMock.mockReturnValue(new Set());
   });
 
   afterEach(() => {
     cancelAll();
     vi.useRealTimers();
+    bindingKeysMock.mockReset();
   });
 
   describe('createInterfaceAdvertiser', () => {
@@ -557,6 +571,92 @@ describe('advertise', () => {
       await vi.advanceTimersByTimeAsync(7000);
 
       expect(mockSockets.get('en1')!.closed).toBe(true);
+    });
+
+    describe('FAILED interface retry', () => {
+      // Create a mock socket that bails to FAILED quickly: refresh always
+      // fails, socket starts closed.
+      const createBailingSocket = () => {
+        const socket = createMockSocket();
+        vi.spyOn(socket, 'refresh').mockReturnValue(false);
+        socket.close();
+        return socket;
+      };
+
+      const buildServices = (interfaceList: () => string[]) => {
+        const createSocketSpy = vi
+          .fn()
+          .mockImplementation((_iname, socketParams) => {
+            const socket = createBailingSocket();
+            socket.params = socketParams;
+            return socket;
+          });
+        const services: Services = {
+          onError: vi.fn(),
+          createSocket: createSocketSpy,
+          createScheduler,
+          createServiceInput,
+          createServiceRecord,
+          networkInterfaceNames: interfaceList,
+          hostname() {
+            return 'testhost';
+          },
+        };
+        return { services, createSocketSpy };
+      };
+
+      it('retries a FAILED handle when bindings change', async () => {
+        bindingKeysMock.mockReturnValue(new Set(['10.0.0.1/255.255.255.0']));
+        const { services, createSocketSpy } = buildServices(() => ['en0']);
+
+        advertiseInternal(createTestParams(), services);
+        expect(createSocketSpy).toHaveBeenCalledTimes(1);
+
+        // First handle bails to FAILED (~90s via reopen counter)
+        await vi.advanceTimersByTimeAsync(120000);
+        // First polling observation records the bindings
+        await vi.advanceTimersByTimeAsync(7000);
+        expect(createSocketSpy).toHaveBeenCalledTimes(1);
+
+        bindingKeysMock.mockReturnValue(new Set(['10.0.0.2/255.255.255.0']));
+
+        // Next polling cycle observes the change and recreates
+        await vi.advanceTimersByTimeAsync(7000);
+        expect(createSocketSpy).toHaveBeenCalledTimes(2);
+      });
+
+      it('does not retry when bindings are unchanged', async () => {
+        bindingKeysMock.mockReturnValue(new Set(['10.0.0.1/255.255.255.0']));
+        const { services, createSocketSpy } = buildServices(() => ['en0']);
+
+        advertiseInternal(createTestParams(), services);
+
+        await vi.advanceTimersByTimeAsync(180000);
+
+        expect(createSocketSpy).toHaveBeenCalledTimes(1);
+      });
+
+      it('clears binding state when iname disappears and reappears', async () => {
+        bindingKeysMock.mockReturnValue(new Set(['10.0.0.1/255.255.255.0']));
+        let interfaces = ['en0'];
+        const { services, createSocketSpy } = buildServices(() => interfaces);
+
+        advertiseInternal(createTestParams(), services);
+
+        // Wait for bail + first bindings observation
+        await vi.advanceTimersByTimeAsync(120000);
+        await vi.advanceTimersByTimeAsync(7000);
+        expect(createSocketSpy).toHaveBeenCalledTimes(1);
+
+        interfaces = [];
+        await vi.advanceTimersByTimeAsync(7000);
+
+        // Reappears with identical bindings — without the cleanup, the cached
+        // entry would block recreation
+        interfaces = ['en0'];
+        await vi.advanceTimersByTimeAsync(7000);
+        expect(createSocketSpy).toHaveBeenCalledTimes(2);
+      });
     });
   });
 

--- a/src/__tests__/advertise.test.ts
+++ b/src/__tests__/advertise.test.ts
@@ -612,8 +612,8 @@ describe('advertise', () => {
         advertiseInternal(createTestParams(), services);
         expect(createSocketSpy).toHaveBeenCalledTimes(1);
 
-        // First handle bails to FAILED (~90s via reopen counter)
-        await vi.advanceTimersByTimeAsync(120000);
+        // First handle bails to FAILED (~30s via reopen counter)
+        await vi.advanceTimersByTimeAsync(60000);
         // First polling observation records the bindings
         await vi.advanceTimersByTimeAsync(7000);
         expect(createSocketSpy).toHaveBeenCalledTimes(1);
@@ -667,8 +667,8 @@ describe('advertise', () => {
 
         advertiseInternal(createTestParams(), services);
 
-        // Advance just past bail so the .then() microtask runs
-        await vi.advanceTimersByTimeAsync(92000);
+        // Advance just past bail (~30s) so the .then() microtask runs
+        await vi.advanceTimersByTimeAsync(32000);
 
         // Change bindings before the next polling cycle fires
         bindingKeysMock.mockReturnValue(new Set(['fp-after-bail']));
@@ -776,8 +776,8 @@ describe('advertise', () => {
       let refreshCount = 0;
       vi.spyOn(mockSocket, 'refresh').mockImplementation(() => {
         refreshCount++;
-        // 14 failures, then one success, then failures forever
-        return refreshCount === 15 ? realRefresh() : false;
+        // 4 failures, then one success, then failures forever
+        return refreshCount === 5 ? realRefresh() : false;
       });
       const services = createMockServices(mockSocket);
       mockSocket.close();
@@ -785,12 +785,12 @@ describe('advertise', () => {
       const handle = createInterfaceAdvertiser('en0', params, services);
 
       // Without per-call reset, the next failure after the success would push
-      // the counter to 15 and bail at ~97s
-      await vi.advanceTimersByTimeAsync(120000);
+      // the counter to 5 and bail at ~37s
+      await vi.advanceTimersByTimeAsync(45000);
       expect(services.errors).toEqual([]);
 
-      // With per-call reset, bail happens after a fresh 15 failures (~181s)
-      await vi.advanceTimersByTimeAsync(80000);
+      // With per-call reset, bail happens after a fresh 5 failures (~61s)
+      await vi.advanceTimersByTimeAsync(30000);
       await handle.promise;
       expect(services.errors.length).toBeGreaterThan(0);
     });

--- a/src/__tests__/advertise.test.ts
+++ b/src/__tests__/advertise.test.ts
@@ -657,6 +657,26 @@ describe('advertise', () => {
         await vi.advanceTimersByTimeAsync(7000);
         expect(createSocketSpy).toHaveBeenCalledTimes(2);
       });
+
+      it('records bindings at settle time, not at the first polling cycle', async () => {
+        // Verifies the .then() hook: bindings change between bail and the next
+        // poll. Without the hook, the change is aliased away by the first
+        // polling observation and we never retry.
+        bindingKeysMock.mockReturnValue(new Set(['fp-at-bail']));
+        const { services, createSocketSpy } = buildServices(() => ['en0']);
+
+        advertiseInternal(createTestParams(), services);
+
+        // Advance just past bail so the .then() microtask runs
+        await vi.advanceTimersByTimeAsync(92000);
+
+        // Change bindings before the next polling cycle fires
+        bindingKeysMock.mockReturnValue(new Set(['fp-after-bail']));
+
+        await vi.advanceTimersByTimeAsync(10000);
+
+        expect(createSocketSpy).toHaveBeenCalledTimes(2);
+      });
     });
   });
 
@@ -789,6 +809,23 @@ describe('advertise', () => {
       const errorsBefore = services.errors.length;
       await expect(handle.close()).resolves.toBeUndefined();
       expect(services.errors.length).toBe(errorsBefore);
+    });
+
+    it('preserves bindings on the handle after the advertiser bails', async () => {
+      // Without the finalBindings snapshot, handle.bindings would be empty
+      // post-bail (the IIFE finally has already closed the socket).
+      const params = createTestParams();
+      const mockSocket = createMockSocket();
+      vi.spyOn(mockSocket, 'refresh').mockReturnValue(false);
+      const services = createMockServices(mockSocket);
+
+      const handle = createInterfaceAdvertiser('en0', params, services);
+
+      await vi.advanceTimersByTimeAsync(150000);
+      await handle.promise;
+
+      expect(mockSocket.closed).toBe(true);
+      expect(handle.bindings.length).toBeGreaterThan(0);
     });
   });
 

--- a/src/advertise.ts
+++ b/src/advertise.ts
@@ -9,6 +9,13 @@ import {
   PROBE_FAILURE_LIMIT,
   Services,
 } from './constants';
+
+import {
+  interfaceBindingKeys,
+  compareInterfaceBindingKeys,
+  NetworkBinding,
+} from './nics';
+
 import {
   TxtValue,
   ConflictFlag,
@@ -64,6 +71,8 @@ const enum AdvertiserState {
 
 export interface AdvertiserHandle {
   readonly promise: Promise<void>;
+  readonly settled: boolean;
+  readonly bindings: NetworkBinding[];
   close(): Promise<void>;
 }
 
@@ -278,6 +287,8 @@ export function createInterfaceAdvertiser(
   }
 
   let closed = false;
+  let settled = false;
+  let finalBindings: NetworkBinding[] = [];
   return {
     promise: (async () => {
       try {
@@ -289,12 +300,22 @@ export function createInterfaceAdvertiser(
           services.onError(error);
         }
       } finally {
+        settled = true;
         if (!closed) {
+          // Snapshot bindings before socket.close() so the polling hook can
+          // observe the state at bail time.
+          finalBindings = socket.bindings;
           socket.close();
           scheduler.cancel();
         }
       }
     })(),
+    get settled() {
+      return settled;
+    },
+    get bindings() {
+      return settled ? finalBindings : socket.bindings;
+    },
     async close() {
       try {
         closed = true;
@@ -326,28 +347,58 @@ export function advertiseInternal(
 ): () => Promise<void> {
   const inames = new Set(services.networkInterfaceNames());
   const handles = new Map<string, AdvertiserHandle>();
+  const bindingKeys = new Map<string, Set<string>>();
   const scheduler = services.createScheduler();
 
+  const createHandle = (iname: string): AdvertiserHandle => {
+    const handle = createInterfaceAdvertiser(iname, params, services);
+    handle.promise
+      .then(() => {
+        if (handles.get(iname) === handle) {
+          bindingKeys.set(iname, interfaceBindingKeys(handle.bindings));
+        }
+      })
+      .catch(error => {
+        if (!AbortError.isAbortError(error)) {
+          services.onError(error);
+        }
+      });
+    return handle;
+  };
+
   for (const iname of inames) {
-    handles.set(iname, createInterfaceAdvertiser(iname, params, services));
+    handles.set(iname, createHandle(iname));
   }
 
   scheduler
     .schedule(TaskKind.REOPEN, task => {
       try {
         const inames = new Set(services.networkInterfaceNames());
-        for (const iname of inames) {
-          if (!handles.has(iname)) {
-            handles.set(
-              iname,
-              createInterfaceAdvertiser(iname, params, services)
-            );
-          }
-        }
+
         for (const [iname, handle] of handles) {
           if (!inames.has(iname)) {
             handles.delete(iname);
+            bindingKeys.delete(iname);
             handle.close();
+          }
+        }
+
+        for (const [iname, handle] of handles) {
+          if (handle.settled) {
+            const currentKeys = interfaceBindingKeys(handle.bindings);
+            const prevKeys = bindingKeys.get(iname);
+            if (prevKeys === undefined) {
+              bindingKeys.set(iname, currentKeys);
+            } else if (!compareInterfaceBindingKeys(prevKeys, currentKeys)) {
+              handles.delete(iname);
+              bindingKeys.delete(iname);
+            }
+          }
+        }
+
+        for (const iname of inames) {
+          if (!handles.has(iname)) {
+            handles.set(iname, createHandle(iname));
           }
         }
       } catch (error) {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -25,7 +25,7 @@ export const DNSSD_NAME = '_services._dns-sd._udp.local';
 export const SCHEDULER_WINDOW = 100;
 export const SCHEDULER_MIN = 20;
 
-export const REOPEN_FAILURE_LIMIT = 15;
+export const REOPEN_FAILURE_LIMIT = 5;
 export const PROBE_CONFLICT_LIMIT = 15;
 export const PROBE_FAILURE_LIMIT = 15;
 

--- a/src/nics.ts
+++ b/src/nics.ts
@@ -46,7 +46,7 @@ export const interfaceBindings = (
     [iname]?.filter(binding => binding.family === family)
     .map(binding => ({ ...binding, family, iname }));
   if (bindings && family === IPType.v6) {
-    bindings?.sort((a, b) => {
+    bindings.sort((a, b) => {
       if (a.address.startsWith('fe80:')) {
         return 1;
       } else if (b.address.startsWith('fe80:')) {
@@ -55,6 +55,8 @@ export const interfaceBindings = (
         return a.address < b.address ? -1 : 1;
       }
     });
+  } else if (bindings && family === IPType.v4) {
+    bindings.sort((a, b) => (a.address < b.address ? -1 : 1));
   }
   return bindings?.length ? bindings : undefined;
 };
@@ -63,6 +65,29 @@ export const hasScopeid = (
   bind: NetworkBinding
 ): bind is NetworkBinding & { scopeid: number } => {
   return bind.scopeid != null && bind.scopeid > 0;
+};
+
+export const interfaceBindingKeys = (
+  bindings: NetworkBinding[]
+): Set<string> => {
+  const keys = new Set<string>();
+  for (const b of bindings) {
+    if (b.family === IPType.v6) {
+      keys.add(`${b.address}/${b.netmask}#${b.scopeid ?? ''}`);
+    } else {
+      keys.add(`${b.address}/${b.netmask}`);
+    }
+  }
+  return keys;
+};
+
+export const compareInterfaceBindingKeys = (
+  a: Set<string>,
+  b: Set<string>
+): boolean => {
+  if (a.size !== b.size) return false;
+  for (const key of a) if (!b.has(key)) return false;
+  return true;
 };
 
 let _hostname: string | undefined;


### PR DESCRIPTION
## Summary

#29 tightens the retry loop and failure state handling, but it doesn't address the underlying problem of network interface changes. Previously, the assumption was that we'd hold a NIC "open" in advertising + reopen when, so it can automatically capture its own changes. However, if advertising entirely fails on the NIC, this doesn't hold and we retry indefinitely until the timeout (90s due to 15 retries).

This isn't ideal, and we should instead fail sooner and retry only when the NIC's network bindings change.

### Set of changes

- Capture network binding "fingerprint" into `Set<string>`
- Reopen NIC if bindings change
- Reduce `REOPEN_FAILURE_LIMIT` to `5`