### PR TITLE
fix: Bail fast on initial setup

### DIFF
--- a/.changeset/sweet-dragons-sing.md
+++ b/.changeset/sweet-dragons-sing.md
@@ -1,0 +1,5 @@
+---
+'dnssd-advertise': patch
+---
+
+Bail faster on setup failures

--- a/src/__tests__/advertise.test.ts
+++ b/src/__tests__/advertise.test.ts
@@ -70,7 +70,8 @@ const createTestParams = (
 });
 
 const createMockSocket = (
-  bindings: NetworkBinding[] = createTestBindings()
+  bindings: NetworkBinding[] = createTestBindings(),
+  initialSetup = true
 ): Socket & {
   params: SocketParams | null;
   sentMessages: Uint8Array[];
@@ -81,6 +82,7 @@ const createMockSocket = (
   ) => Promise<void>;
 } => {
   let closed = false;
+  let setup = initialSetup;
   let currentBindings = bindings;
   const sentMessages: Uint8Array[] = [];
 
@@ -99,6 +101,9 @@ const createMockSocket = (
     get bindings() {
       return closed ? [] : currentBindings;
     },
+    get setup() {
+      return setup;
+    },
     params: null,
     sentMessages,
     async send(message: Uint8Array) {
@@ -109,6 +114,7 @@ const createMockSocket = (
     refresh() {
       if (closed) {
         closed = false;
+        setup = true;
         return true;
       }
       return false;
@@ -809,6 +815,50 @@ describe('advertise', () => {
       const errorsBefore = services.errors.length;
       await expect(handle.close()).resolves.toBeUndefined();
       expect(services.errors.length).toBe(errorsBefore);
+    });
+
+    it('fails fast when the socket never successfully set up', async () => {
+      const params = createTestParams();
+      // initialSetup=false models a socket whose initial setupSocket() failed
+      // (e.g., kernel rejected addMembership for IFF_MULTICAST-absent interface)
+      const mockSocket = createMockSocket(undefined, false);
+      vi.spyOn(mockSocket, 'refresh').mockReturnValue(false);
+      const services = createMockServices(mockSocket);
+      mockSocket.close();
+
+      const handle = createInterfaceAdvertiser('en0', params, services);
+
+      // Bail at ~12s with REOPEN_INITIAL_FAILURE_LIMIT=2 — well under 30s
+      await vi.advanceTimersByTimeAsync(20000);
+      await handle.promise;
+
+      expect(services.errors.length).toBeGreaterThan(0);
+      const message =
+        services.errors[0] instanceof Error
+          ? services.errors[0].message
+          : String(services.errors[0]);
+      expect(message).toContain('en0');
+      expect(message).toContain('initial setup');
+    });
+
+    it('uses the full retry budget once the socket has been set up', async () => {
+      const params = createTestParams();
+      // Default initialSetup=true models an interface that came up at least once
+      const mockSocket = createMockSocket();
+      vi.spyOn(mockSocket, 'refresh').mockReturnValue(false);
+      const services = createMockServices(mockSocket);
+      mockSocket.close();
+
+      const handle = createInterfaceAdvertiser('en0', params, services);
+
+      // Should NOT have bailed by the fail-fast deadline (~12s)
+      await vi.advanceTimersByTimeAsync(15000);
+      expect(services.errors).toEqual([]);
+
+      // Bails at the full ~30s budget
+      await vi.advanceTimersByTimeAsync(20000);
+      await handle.promise;
+      expect(services.errors.length).toBeGreaterThan(0);
     });
 
     it('preserves bindings on the handle after the advertiser bails', async () => {

--- a/src/advertise.ts
+++ b/src/advertise.ts
@@ -5,6 +5,7 @@ import { AbortError, TaskKind } from './scheduler';
 import {
   defaultServices,
   REOPEN_FAILURE_LIMIT,
+  REOPEN_INITIAL_FAILURE_LIMIT,
   PROBE_CONFLICT_LIMIT,
   PROBE_FAILURE_LIMIT,
   Services,
@@ -242,11 +243,16 @@ export function createInterfaceAdvertiser(
           return;
         }
         if (!socket.refresh() || socket.closed) {
-          if (++reopenFailures >= REOPEN_FAILURE_LIMIT) {
+          const limit = socket.setup
+            ? REOPEN_FAILURE_LIMIT
+            : REOPEN_INITIAL_FAILURE_LIMIT;
+          if (++reopenFailures >= limit) {
             state = AdvertiserState.FAILED;
             services.onError(
               new Error(
-                `mDNS unavailable on interface "${iname}" after ${reopenFailures} setup attempts`
+                socket.setup
+                  ? `mDNS unavailable on interface "${iname}" after ${reopenFailures} setup attempts`
+                  : `mDNS interface "${iname}" failed initial setup after ${reopenFailures} attempts`
               )
             );
             return;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -26,6 +26,7 @@ export const SCHEDULER_WINDOW = 100;
 export const SCHEDULER_MIN = 20;
 
 export const REOPEN_FAILURE_LIMIT = 5;
+export const REOPEN_INITIAL_FAILURE_LIMIT = 2;
 export const PROBE_CONFLICT_LIMIT = 15;
 export const PROBE_FAILURE_LIMIT = 15;
 

--- a/src/socket.ts
+++ b/src/socket.ts
@@ -40,6 +40,7 @@ export interface SocketParams {
 
 export interface Socket {
   readonly closed: boolean;
+  readonly setup: boolean;
   readonly bindings: NetworkBinding[];
   send(message: Uint8Array): Promise<void>;
   refresh(): boolean;
@@ -119,6 +120,7 @@ const createInterfaceSocket = (
   const messageQueue: QueuedMessage[] = [];
 
   let timer: Promise<void> | null = null;
+  let setup = false;
   let state: SocketState | null = initSocket();
 
   function initSocket() {
@@ -247,6 +249,7 @@ const createInterfaceSocket = (
       return false;
     } else if (state) {
       state.settings = newSettings;
+      setup = true;
     }
     return hasChanged;
   }
@@ -326,6 +329,9 @@ const createInterfaceSocket = (
     get closed() {
       return !state;
     },
+    get setup() {
+      return setup;
+    },
     get bindings() {
       return state?.settings.bindings ?? [];
     },
@@ -376,6 +382,9 @@ export const createSocket = (iname: string, params: SocketParams): Socket => {
       return dualSocket
         ? [...singleSocket.bindings, ...dualSocket.bindings]
         : singleSocket.bindings;
+    },
+    get setup() {
+      return singleSocket.setup || !!dualSocket?.setup;
     },
     async send(message: Uint8Array) {
       await Promise.all([


### PR DESCRIPTION
## Summary

Follow-up to #31 

On an initial setup, we should be faster to bail when encountering a failure. Some NICs advertise multicast support or fail setup, and shouldn't be retried more than twice (once more for tansient failures)

## Set of changes

- Track if initial setup succeeded on sockets
- Reduce retry attempts on initial setup