### PR TITLE
fix: Fix network binding change detection

### DIFF
--- a/.changeset/better-stamps-obey.md
+++ b/.changeset/better-stamps-obey.md
@@ -1,0 +1,5 @@
+---
+'dnssd-advertise': patch
+---
+
+Use live network bindings to diff network interface changes

--- a/src/__tests__/advertise.test.ts
+++ b/src/__tests__/advertise.test.ts
@@ -1,14 +1,14 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
-const { bindingKeysMock } = vi.hoisted(() => ({
-  bindingKeysMock: vi.fn<(bindings: unknown[]) => Set<string>>(),
+const { interfaceBindingsMock } = vi.hoisted(() => ({
+  interfaceBindingsMock: vi.fn(),
 }));
 
 vi.mock('../nics', async () => {
   const actual = await vi.importActual<typeof import('../nics')>('../nics');
   return {
     ...actual,
-    interfaceBindingKeys: bindingKeysMock,
+    interfaceBindings: interfaceBindingsMock,
   };
 });
 
@@ -174,13 +174,17 @@ const createMockServices = (
 describe('advertise', () => {
   beforeEach(() => {
     vi.useFakeTimers();
-    bindingKeysMock.mockReturnValue(new Set());
+    interfaceBindingsMock.mockImplementation((iname: string, family: IPType) =>
+      createTestBindings().filter(
+        binding => binding.iname === iname && binding.family === family
+      )
+    );
   });
 
   afterEach(() => {
     cancelAll();
     vi.useRealTimers();
-    bindingKeysMock.mockReset();
+    interfaceBindingsMock.mockReset();
   });
 
   describe('createInterfaceAdvertiser', () => {
@@ -611,8 +615,17 @@ describe('advertise', () => {
         return { services, createSocketSpy };
       };
 
+      const setInterfaceBindings = (bindings: NetworkBinding[]) => {
+        interfaceBindingsMock.mockImplementation(
+          (iname: string, family: IPType) =>
+            bindings.filter(
+              binding => binding.iname === iname && binding.family === family
+            )
+        );
+      };
+
       it('retries a FAILED handle when bindings change', async () => {
-        bindingKeysMock.mockReturnValue(new Set(['10.0.0.1/255.255.255.0']));
+        setInterfaceBindings(createTestBindings());
         const { services, createSocketSpy } = buildServices(() => ['en0']);
 
         advertiseInternal(createTestParams(), services);
@@ -624,7 +637,14 @@ describe('advertise', () => {
         await vi.advanceTimersByTimeAsync(7000);
         expect(createSocketSpy).toHaveBeenCalledTimes(1);
 
-        bindingKeysMock.mockReturnValue(new Set(['10.0.0.2/255.255.255.0']));
+        setInterfaceBindings([
+          {
+            ...createTestBindings()[0],
+            address: '192.168.1.101',
+            cidr: '192.168.1.101/24',
+          },
+          createTestBindings()[1],
+        ]);
 
         // Next polling cycle observes the change and recreates
         await vi.advanceTimersByTimeAsync(7000);
@@ -632,7 +652,7 @@ describe('advertise', () => {
       });
 
       it('does not retry when bindings are unchanged', async () => {
-        bindingKeysMock.mockReturnValue(new Set(['10.0.0.1/255.255.255.0']));
+        setInterfaceBindings(createTestBindings());
         const { services, createSocketSpy } = buildServices(() => ['en0']);
 
         advertiseInternal(createTestParams(), services);
@@ -643,7 +663,7 @@ describe('advertise', () => {
       });
 
       it('clears binding state when iname disappears and reappears', async () => {
-        bindingKeysMock.mockReturnValue(new Set(['10.0.0.1/255.255.255.0']));
+        setInterfaceBindings(createTestBindings());
         let interfaces = ['en0'];
         const { services, createSocketSpy } = buildServices(() => interfaces);
 
@@ -664,11 +684,8 @@ describe('advertise', () => {
         expect(createSocketSpy).toHaveBeenCalledTimes(2);
       });
 
-      it('records bindings at settle time, not at the first polling cycle', async () => {
-        // Verifies the .then() hook: bindings change between bail and the next
-        // poll. Without the hook, the change is aliased away by the first
-        // polling observation and we never retry.
-        bindingKeysMock.mockReturnValue(new Set(['fp-at-bail']));
+      it('detects bindings changed between settle and first poll', async () => {
+        setInterfaceBindings(createTestBindings());
         const { services, createSocketSpy } = buildServices(() => ['en0']);
 
         advertiseInternal(createTestParams(), services);
@@ -677,7 +694,14 @@ describe('advertise', () => {
         await vi.advanceTimersByTimeAsync(32000);
 
         // Change bindings before the next polling cycle fires
-        bindingKeysMock.mockReturnValue(new Set(['fp-after-bail']));
+        setInterfaceBindings([
+          {
+            ...createTestBindings()[0],
+            address: '192.168.1.101',
+            cidr: '192.168.1.101/24',
+          },
+          createTestBindings()[1],
+        ]);
 
         await vi.advanceTimersByTimeAsync(10000);
 
@@ -861,9 +885,7 @@ describe('advertise', () => {
       expect(services.errors.length).toBeGreaterThan(0);
     });
 
-    it('preserves bindings on the handle after the advertiser bails', async () => {
-      // Without the finalBindings snapshot, handle.bindings would be empty
-      // post-bail (the IIFE finally has already closed the socket).
+    it('recomputes bindings on the handle after the advertiser bails', async () => {
       const params = createTestParams();
       const mockSocket = createMockSocket();
       vi.spyOn(mockSocket, 'refresh').mockReturnValue(false);

--- a/src/advertise.ts
+++ b/src/advertise.ts
@@ -8,6 +8,7 @@ import {
   REOPEN_INITIAL_FAILURE_LIMIT,
   PROBE_CONFLICT_LIMIT,
   PROBE_FAILURE_LIMIT,
+  IPType,
   Services,
 } from './constants';
 
@@ -15,6 +16,7 @@ import {
   interfaceBindingKeys,
   compareInterfaceBindingKeys,
   NetworkBinding,
+  interfaceBindings,
 } from './nics';
 
 import {
@@ -294,7 +296,6 @@ export function createInterfaceAdvertiser(
 
   let closed = false;
   let settled = false;
-  let finalBindings: NetworkBinding[] = [];
   return {
     promise: (async () => {
       try {
@@ -308,9 +309,6 @@ export function createInterfaceAdvertiser(
       } finally {
         settled = true;
         if (!closed) {
-          // Snapshot bindings before socket.close() so the polling hook can
-          // observe the state at bail time.
-          finalBindings = socket.bindings;
           socket.close();
           scheduler.cancel();
         }
@@ -320,7 +318,18 @@ export function createInterfaceAdvertiser(
       return settled;
     },
     get bindings() {
-      return settled ? finalBindings : socket.bindings;
+      if (!settled && !socket.closed) {
+        return socket.bindings;
+      } else if (params.stack === 'IPv4') {
+        return interfaceBindings(iname, IPType.v4) ?? [];
+      } else if (params.stack === 'IPv6') {
+        return interfaceBindings(iname, IPType.v6) ?? [];
+      } else {
+        return [
+          ...(interfaceBindings(iname, IPType.v4) ?? []),
+          ...(interfaceBindings(iname, IPType.v6) ?? []),
+        ];
+      }
     },
     async close() {
       try {


### PR DESCRIPTION
## Summary

The change for detecting network bindings changes was made ineffective accidentally by capturing "final" bindings when the socket closes. However, when the socket settles/closes, we'd like to check for binding changes, so we need to check against the live bindings.

## Set of changes

- Override bindings when socket settles or is closed
- Update tests